### PR TITLE
Внес правки проверяющего

### DIFF
--- a/catalog.html
+++ b/catalog.html
@@ -60,6 +60,48 @@
                   </svg>
                   Корзина
                 </a>
+                <div class="popover popover-cart">
+                  <div class="popover-content">
+                    <h2 class="visually-hidden">Корзина</h2>
+                    <ul class="cart-items-list">
+                      <li class="cart-item">
+                        <div class="cart-item-wrapper">
+                          <a class="cart-link" href="#">
+                            <img class="cart-item-image" src="images/product-1-small.jpg" width="39" height="43" alt="Селфи-палка">
+                            <p class="cart-item-title">Любительская<br>
+                            селфи-палка</p>
+                          </a>
+                          <button class="button-delete">
+                            <span class="visually-hidden">Удалить позицию</span>
+                            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+                              <path d="M10 .909 9.091 0 5 4.091.909 0 0 .909 4.091 5 0 9.091.909 10 5 5.909 9.091 10 10 9.091 5.909 5 10 .909Z" fill="#fff"/>
+                            </svg>
+                          </button>
+                        </div>
+                      </li>
+                      <li class="cart-item">
+                        <div class="cart-item-wrapper">
+                          <a class="cart-link" href="#">
+                            <img class="cart-item-image" src="images/product-2-small.jpg" width="39" height="43" alt="Селфи-палка">
+                            <p class="cart-item-title">Профессиональная<br>
+                             селфи-палка</p>
+                          </a>
+                          <button class="button-delete" type="button">
+                            <span class="visually-hidden">Удалить позицию</span>
+                            <svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+                              <path d="M10 .909 9.091 0 5 4.091.909 0 0 .909 4.091 5 0 9.091.909 10 5 5.909 9.091 10 10 9.091 5.909 5 10 .909Z" fill="#fff"/>
+                            </svg>
+                          </button>
+                        </div>
+                      </li>
+                    </ul>
+                    <div class="basket-info">
+                      <p class="positions-amount">Товаров: 2</p>
+                      <p class="total-price">Сумма: 2000 ₽</p>
+                    </div>
+                    <button class="button-open-basket" type="button">Открыть корзину</button>
+                  </div>
+                </div>
               </li>
             </ul>
           </li>

--- a/images/Ellipse 11.svg
+++ b/images/Ellipse 11.svg
@@ -1,3 +1,0 @@
-<svg width="9" height="8" viewBox="0 0 9 8" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="4.50006" cy="4" r="4" fill="#FFC700"/>
-</svg>

--- a/index.html
+++ b/index.html
@@ -58,8 +58,7 @@
                   </svg>
                   Корзина
                 </a>
-                <div class="popover popover-cart">
-
+                <div class="popover popover-cart popover-opened">
                   <div class="popover-content">
                     <h2 class="visually-hidden">Корзина</h2>
                     <ul class="cart-items-list">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -35,6 +35,7 @@ html {
 }
 
 body {
+  min-height: 1160px;
   display: flex;
   flex-direction: column;
   min-height: 100%;
@@ -439,7 +440,7 @@ body {
 
 .button-show-categories:active.button-show-categories::after {
   opacity: 1;
-  background-image: url("../images/minus.svg")
+  background-image: url("../images/minus.svg");
 }
 
 
@@ -448,10 +449,13 @@ body {
   outline: none;
 }
 
-.button-show-categories-press + .catalog-popover {
-  display: block;
+.navigation-site-item-catalog:hover .button-show-categories::after {
+  background-image: url("../images/minus.svg");
 }
 
+.navigation-site-item-catalog:hover .catalog-popover {
+  display: block;
+}
 
 .navigation-site-item-catalog {
   position: relative;
@@ -465,7 +469,7 @@ body {
   left: -60px;
   padding-left: 60px;
   padding-top: 32px;
-  padding-bottom: 32px;
+  padding-bottom: 55px;
   background-color: #FFE17F;
 }
 
@@ -475,20 +479,18 @@ body {
 
 .catalog-popover-list {
   display: flex;
-  flex-direction: column;
   list-style: none;
   padding: 0;
   margin: 0;
-  margin-right: 40px;
   column-count: 3;
-}
-
-.catalog-popover-list:last-child {
-  margin-right: 0;
+  margin-right: auto;
+  column-gap: 5px;
 }
 
 .catalog-popover-item {
   margin-bottom: 5px;
+  margin-right: 60px;
+  min-width: 193px;
 }
 
 .catalog-popover-link {
@@ -2359,7 +2361,6 @@ body {
 }
 
 .popover {
-  display: none;
   position: absolute;
   top: 35px;
   left: -140%;
@@ -2372,6 +2373,11 @@ body {
   color: #ffffff;
   background-color: #000000;
   min-height: 190px;
+  display: none;
+}
+
+.popover-opened {
+  display: block;
 }
 
 .popover-content {


### PR DESCRIPTION
1.  Сделал появление подменю при наведении на КАТАЛОГ.
2.  Попап под корзиной уже был. Сделал его видимым на главной странице с помощью класса "popover-opened".
3.  Модальное окно также уже было. Чтобы оно отобразилось нужно у html-элемента с классом "modal-container" убрать класс "modal-container-close". Элемент находится после footer в конце
4.  Неиспользуемое изображение удалил

*Переход на страницу с каталогом моноподов осуществляется через пункт во всплывающем подменю "Моноподы для селфи" и ссылку с иконкой в разделе "device-categories"